### PR TITLE
Dev/rog3rsm1th

### DIFF
--- a/frelatage/__init__.py
+++ b/frelatage/__init__.py
@@ -7,6 +7,7 @@ from frelatage.queue.queue import Queue
 from typing import Type, Iterable, Callable, List
 from importlib.metadata import version
 from datetime import datetime
+from pathlib import Path
 import warnings
 import time
 import sys
@@ -88,10 +89,10 @@ class Fuzzer(object):
             os.path.dirname(os.path.realpath(sys.argv[0])),
             Config.FRELATAGE_INPUT_DIR
         )
-        self.output_directory = os.path.join(
+        self.output_directory = Path(os.path.join(
             os.path.dirname(os.path.realpath(sys.argv[0])),
             output_directory
-        )
+        )).as_posix()
         
         # Silent output
         self.silent = silent

--- a/frelatage/mutator/mutator.py
+++ b/frelatage/mutator/mutator.py
@@ -338,7 +338,7 @@ class MutatorNone(Mutator):
 
     @staticmethod
     def mutate(input: None) -> Any:
-        types = ["a", 0, [], {}, 1.0]
+        types = ["a", 0, [], {}, 1.0, ()]
         mutation = random.choice(types)
         return mutation
 


### PR DESCRIPTION
- Improves the way the output path is displayed. Before: `your/path/./out`, after: `your/path/out`.
- Allows None values to mutate to tuples